### PR TITLE
Misc. cleanup before release

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -206,7 +206,3 @@ Licenses for dependency projects can be found here:
 [http://akka.io/docs/akka/current/project/licenses.html]
 
 ---------------
-
-akka-protobuf contains the sources of Google protobuf 2.5.0 runtime support,
-moved into the source package `akka.protobuf` so as to avoid version conflicts.
-For license information see COPYING.protobuf

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -97,11 +97,9 @@ object Dependencies {
   )
 
   val akkaPersistencePlugins = Seq(
-    "com.typesafe.akka" %% "akka-persistence-cassandra"          % AkkaPersistenceCassandra,
-    "com.typesafe.akka" %% "akka-persistence-cassandra-launcher" % AkkaPersistenceCassandra,
-    // FIXME: couchbase hasn't been published for a release version of Scala 2.13
-    //"com.lightbend.akka" %% "akka-persistence-couchbase" % AkkaPersistenceCouchbase,
-    "com.lightbend.akka" %% "akka-persistence-jdbc" % AkkaPersistenceJdbc
+    "com.typesafe.akka"  %% "akka-persistence-cassandra"          % AkkaPersistenceCassandra,
+    "com.typesafe.akka"  %% "akka-persistence-cassandra-launcher" % AkkaPersistenceCassandra,
+    "com.lightbend.akka" %% "akka-persistence-jdbc"               % AkkaPersistenceJdbc
   )
 
   val alpakka = Seq(


### PR DESCRIPTION
* Truncate license to just Apache v2
* Drop couchbase dep that hasn't been published for 2.13 yet