### PR TITLE
Prepare to publish new release

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   check:
     name: Check
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -29,3 +29,6 @@ jobs:
 
       - name: Check scalafmt rules, publish BOM locally
         run: sbt checkBom
+
+      - name: Check open-source dependencies can be pulled
+        run: sbt update

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   publish:
     name: Publish to Sonatype
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,7 @@ jobs:
 
       - name: Check scalafmt rules, pull dependencies, publish BOM locally successfully
         env:
-          # FIXME: required to access commercial lightbend releases, but not for much longer.
-          BINTRAY_TOKEN: ${{ secrets.BINTRAY_TOKEN }}
+          LIGHTBEND_COMMERCIAL_MVN: ${{ secrets.LIGHTBEND_COMMERCIAL_MVN }}
         run: sbt checkPullBom
 
       - name: Sonatype release

--- a/build.sbt
+++ b/build.sbt
@@ -41,9 +41,17 @@ lazy val `akka-platform-dependencies` =
         akkaPersistencePlugins ++
         akkaResilienceEnhancements ++
         alpakka ++
-        Cinnamon.library.modules,
+        telemetry,
       // to check that all dependencies can be pulled and there are no conflicts
-      libraryDependencies := bomIncludeModules.value,
+      libraryDependencies ++= {
+        val bomDeps = bomIncludeModules.value
+        if (sys.env.contains("LIGHTBEND_COMMERCIAL_MVN")) {
+          bomDeps
+        } else {
+          // Run the validation for at least the non-commercial dependencies
+          bomDeps.filterNot(allCommercialLibs.contains)
+        }
+      },
       publishLocalConfiguration := publishLocalConfiguration.value.withOverwrite(true),
       publishM2Configuration := publishM2Configuration.value.withOverwrite(true)
     )

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,18 @@
 import Dependencies._
 
+ThisBuild / resolvers ++= sys.env
+  .get("LIGHTBEND_COMMERCIAL_MVN")
+  .map { repo =>
+    Seq(
+      "lightbend-commercial-mvn".at(repo),
+      Resolver.url(
+        "lightbend-commercial-ivy",
+        url(repo)
+      )(Resolver.ivyStylePatterns)
+    )
+  }
+  .getOrElse(Seq.empty)
+
 lazy val `akka-platform-dependencies` =
   Project(id = "akka-platform-dependencies", base = file("."))
     .enablePlugins(BillOfMaterialsPlugin)
@@ -32,20 +45,7 @@ lazy val `akka-platform-dependencies` =
       // to check that all dependencies can be pulled and there are no conflicts
       libraryDependencies := bomIncludeModules.value,
       publishLocalConfiguration := publishLocalConfiguration.value.withOverwrite(true),
-      publishM2Configuration := publishM2Configuration.value.withOverwrite(true),
-      // FIXME: required to access lightbend commercial releases, but not for much longer.
-      resolvers in ThisBuild ++= sys.env
-        .get("BINTRAY_TOKEN")
-        .map(token =>
-          Seq(
-            "lightbend-commercial-mvn".at(s"https://repo.lightbend.com/pass/$token/commercial-releases"),
-            Resolver.url(
-              "lightbend-commercial-ivy",
-              url(s"https://repo.lightbend.com/pass/$token/commercial-releases")
-            )(Resolver.ivyStylePatterns)
-          )
-        )
-        .getOrElse(Seq.empty[Resolver])
+      publishM2Configuration := publishM2Configuration.value.withOverwrite(true)
     )
 
 addCommandAlias("checkBom", ";scalafmtSbtCheck;+akka-platform-dependencies/billOfMaterials:publishM2")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
     val AkkaHttp                 = "10.2.4"
     val AkkaManagement           = "1.1.0"
     val AkkaProjections          = "1.2.1"
-    val AkkaGrpc                 = "2.0.0"
+    val AkkaGrpc                 = "1.1.1"
     val AkkaPersistenceCassandra = "1.0.5"
     val AkkaPersistenceJdbc      = "5.0.1"
     val AkkaPersistenceCouchbase = "1.0"
@@ -118,4 +118,9 @@ object Dependencies {
   val akkaResilienceEnhancements = Seq(
     "com.lightbend.akka" %% "akka-diagnostics" % AkkaEnhancements
   )
+
+  // sbt-cinnamon plugin does not have artifacts for Scala 2.13.x
+  val telemetry = com.lightbend.cinnamon.sbt.Cinnamon.library.modules.filterNot(_.name.equals("sbt-cinnamon"))
+
+  val allCommercialLibs = akkaResilienceEnhancements ++ telemetry
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.8
+sbt.version=1.5.4


### PR DESCRIPTION
- Update sbt to version 1.5.4
- Run builds on ubuntu 20.04
- Use new env var to get access to commercial repository
- Build check that dependencies can be pulled

Besides that, it downgrades Akka gRCP to version 1.1.1 which contains all the artifacts for Scala 2.13. See https://github.com/akka/akka-grpc/issues/1400 for more details.
